### PR TITLE
Support JSON or YAML-encoded extra-vars on job templates

### DIFF
--- a/aap_client.py
+++ b/aap_client.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional, Any
 from pydantic import BaseModel
 from dotenv import load_dotenv
 import asyncio
+import json
+import yaml
 
 load_dotenv()
 
@@ -144,6 +146,12 @@ class AAPClient:
             # Handle empty string extra_vars from API
             if "extra_vars" in template_data and template_data["extra_vars"] == "":
                 template_data["extra_vars"] = None
+            if "extra_vars" in template_data and isinstance(template_data["extra_vars"], str):
+                try:
+                    template_data["extra_vars"] = json.loads(template_data["extra_vars"])
+                except json.JSONDecodeError:
+                    # Try it as yaml
+                    template_data["extra_vars"] = yaml.safe_load(template_data["extra_vars"])
             templates.append(JobTemplate(**template_data))
         
         return templates

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx>=0.25.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
 asyncio-mqtt>=0.11.0 
+pyyaml>=6.0.0


### PR DESCRIPTION
Fix to correctly decode extra-vars (returned from the AAP API as JSON or YAML encoded strings).